### PR TITLE
Added NullPointerException handling to stop the crash on first boot, also added StringIndexOutOfBounds exception handling.

### DIFF
--- a/app/src/main/java/uk/ac/rhul/cyclingprofessor/ev3sensors/MainActivity.java
+++ b/app/src/main/java/uk/ac/rhul/cyclingprofessor/ev3sensors/MainActivity.java
@@ -317,7 +317,16 @@ public class MainActivity extends AppCompatActivity implements ActivityCompat.On
                 case Constants.MESSAGE_READ:
                     byte[] readBuf = (byte[]) msg.obj;
                     // construct a string from the valid bytes in the buffer
-                    String readMessage = new String(readBuf, 0, msg.arg1);
+                    String readMessage;
+                    try {
+                        readMessage = new String(readBuf, 0, msg.arg1);
+                    } catch (StringIndexOutOfBoundsException e) {
+                        Log.e(TAG, "could not read string, is the program running?", e);
+                        activity.setStatus("No EV3 Connected");
+                        System.exit(-1);
+                        break;
+                    }
+
                     activity.receivedItems.add(0, readMessage);
                     activity.listAdapter.notifyDataSetChanged();
                     break;

--- a/app/src/main/java/uk/ac/rhul/cyclingprofessor/ev3sensors/Server.java
+++ b/app/src/main/java/uk/ac/rhul/cyclingprofessor/ev3sensors/Server.java
@@ -164,6 +164,9 @@ class Server {
                 } catch (IOException e) {
                     Log.e(TAG, "Server Socket accept() failed", e);
                     break;
+                } catch (NullPointerException e) {
+                    Log.e(TAG, "Nullpointer exception to stop crash ONLY first boot", e);
+                    break;
                 }
 
                 // If a connection was accepted


### PR DESCRIPTION
This stops the crash that occurs on the first boot. If openCV is not installed it will still crash due to other nullpointers.

Have no EV3 to hand, this may stop connection from occuring and therefore the program may still need to be restarted. This allows for that to be done cleanly instead of an error.